### PR TITLE
Add aarch64 (RPi-4) arch. support logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ ifeq ($(OS),Windows_NT)
 	DFU_UTIL=./$(F1_LIB_PATH)/utils/win/dfu-util.exe
 	STM32FLASH=./$(F1_LIB_PATH)/utils/win/stm32flash.exe
 else
-	CLEANCMD=rm -f $(OBJ_F1BL) $(OBJ_F4) $(OBJ_F7) $(BINDIR)/*.hex $(BINDIR)/mmdvm_f1.bin $(BINDIR)/mmdvm_f1bl.bin $(BINDIR)/mmdvm_f1nobl.bin $(BINDIR)/*.elf $(BINDIR)/*.bin
+	CLEANCMD=rm -f $(OBJ_F1BL) $(OBJ_F4) $(OBJ_F7) $(BINDIR)/*.hex $(BINDIR)/mmdvm_f1.bin $(BINDIR)/mmdvm_f1bl.bin $(BINDIR)/mmdvm_f1nobl.bin $(BINDIR)/*.elf 
 	MDDIRS=mkdir $@
 
 	ifeq ($(shell uname -s),Linux)

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ ifeq ($(OS),Windows_NT)
 	DFU_UTIL=./$(F1_LIB_PATH)/utils/win/dfu-util.exe
 	STM32FLASH=./$(F1_LIB_PATH)/utils/win/stm32flash.exe
 else
-	CLEANCMD=rm -f $(OBJ_F1BL) $(OBJ_F4) $(OBJ_F7) $(BINDIR)/*.hex $(BINDIR)/mmdvm_f1.bin $(BINDIR)/mmdvm_f1bl.bin $(BINDIR)/mmdvm_f1nobl.bin $(BINDIR)/*.elf
+	CLEANCMD=rm -f $(OBJ_F1BL) $(OBJ_F4) $(OBJ_F7) $(BINDIR)/*.hex $(BINDIR)/mmdvm_f1.bin $(BINDIR)/mmdvm_f1bl.bin $(BINDIR)/mmdvm_f1nobl.bin $(BINDIR)/*.elf $(BINDIR)/*.bin
 	MDDIRS=mkdir $@
 
 	ifeq ($(shell uname -s),Linux)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ WPSD & pi-star commands in an SSH console:
 - `sudo pistar-nanohsflash nano_hs`: Nano hotSPOT board
 - `sudo pistar-nanodvflash pi`: NanoDV NPi board
 - `sudo pistar-nanodvflash usb`: NanoDV USB board
-- `sudo pistar-skybridgeflash skybrige`: BridgeCom SkyBridge GPIO Hotspot board
+- `sudo pistar-skybridgeflash skybridge`: BridgeCom SkyBridge GPIO Hotspot board
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This is the source code of ZUMspot/MMDVM_HS firmware for personal hotspots (ADF7021 version of the MMDVM firmware), based on Jonathan G4KLX's [MMDVM](https://github.com/g4klx/MMDVM) software. This firmware supports D-Star, DMR, System Fusion, P25 and NXDN digital voice modes and POCSAG 1200 pager protocol.
+This is the source code of ZUMspot/MMDVM_HS firmware for personal hotspots (ADF7021 version of the MMDVM firmware), based on Jonathan G4KLX's [MMDVM](https://github.com/g4klx/MMDVM) software. This firmware supports D-Star, DMR, System Fusion, P25, NXDN & M17 digital voice modes and POCSAG 1200 pager protocol.
 
 This software is intended to be run on STM32F103 microcontroller. Also, Arduino with 3.3 V I/O (Arduino Due and Zero) and Teensy (3.1, 3.2, 3.5 or 3.6) are supported. You can build this code using Arduino IDE with Roger Clark's [STM32duino](https://github.com/rogerclarkmelbourne/Arduino_STM32/tree/ZUMspot) package, or using command line tools with ARM GCC tools. The preferred method under Windows is using STM32duino, and under Linux or macOS (command line) is using [STM32F10X_Lib](https://github.com/juribeparada/STM32F10X_Lib). 
 
@@ -10,10 +10,10 @@ This software is licenced under the GPL v2 and is intended for amateur and educa
 
 # Features
 
-- Supported modes: D-Star, DMR, Yaesu Fusion, P25 Phase 1 and NXDN
+- Supported modes: D-Star, DMR, Yaesu Fusion, P25 Phase 1, NXDN and M17
 - Other modes: POCSAG 1200
 - Automatic mode detection (scanning)
-- G4KLX software suite: [MMDVMHost](https://github.com/g4klx/MMDVMHost), [ircDDBGateway](https://github.com/g4klx/ircDDBGateway), [YSFGateway](https://github.com/g4klx/YSFClients), [P25Gateway](https://github.com/g4klx/P25Clients), [DMRGateway](https://github.com/g4klx/DMRGateway), [NXDNGateway](https://github.com/g4klx/NXDNClients),
+- G4KLX software suite: [MMDVMHost](https://github.com/g4klx/MMDVMHost), [ircDDBGateway](https://github.com/g4klx/ircDDBGateway), [YSFGateway](https://github.com/g4klx/YSFClients), [P25Gateway](https://github.com/g4klx/P25Clients), [DMRGateway](https://github.com/g4klx/DMRGateway), [NXDNGateway](https://github.com/g4klx/NXDNClients), [M17Gateway](https://github.com/g4klx/M17Gateway), 
 [DAPNETGateway](https://github.com/g4klx/DAPNETGateway) and [MMDVMCal](https://github.com/g4klx/MMDVMCal)
 - Bands: 144, 220, 430 and 900 MHz (VHF requires external inductor)
 - Status LEDs (PTT, COR and digital modes)
@@ -305,6 +305,7 @@ and enable:
     #define ENABLE_SCAN_MODE
     #define USE_ALTERNATE_NXDN_LEDS
     #define USE_ALTERNATE_POCSAG_LEDS
+    #define USE_ALTERNATE_M17_LEDS
 
 Build the firmware:
 

--- a/README.md
+++ b/README.md
@@ -93,21 +93,22 @@ Please see [BUILD.md](BUILD.md) for more details, and also [MMDVM](https://group
 
 Please check the latest firmware [here](https://github.com/juribeparada/MMDVM_HS/releases).
 
-### Pi-Star binary firmware installation
+### WPSD & Pi-Star binary firmware installation
 
-You could use some pi-star commands under SSH console:
+WPSD & pi-star commands in an SSH console:
 
-- sudo pistar-zumspotflash rpi: ZUMspot RPi board
-- sudo pistar-zumspotflash rpi_duplex: ZUMSpot duplex board conected to GPIO
-- sudo pistar-zumspotflash usb: ZUMspot USB dongle
-- sudo pistar-zumspotflash libre: ZUMspot Libre Kit or generic MMDVM_HS board with USB
-- sudo pistar-mmdvmhshatflash hs_hat: MMDVM_HS_Hat board (14.7456MHz TCXO)
-- sudo pistar-mmdvmhshatflash hs_dual_hat: HS_DUAL_HAT board (14.7456MHz TCXO)
-- sudo pistar-mmdvmhshatflash hs_hat-12mhz: MMDVM_HS_Hat board (12.288MHz TCXO)
-- sudo pistar-mmdvmhshatflash hs_dual_hat-12mhz: HS_DUAL_HAT board (12.288MHz TCXO)
-- sudo pistar-nanohsflash nano_hs: Nano hotSPOT board
-- sudo pistar-nanodvflash pi: NanoDV NPi board
-- sudo pistar-nanodvflash usb: NanoDV USB board
+- `sudo pistar-zumspotflash rpi`: ZUMspot RPi board
+- `sudo pistar-zumspotflash rpi_duplex`: ZUMSpot duplex board conected to GPIO
+- `sudo pistar-zumspotflash usb`: ZUMspot USB dongle
+- `sudo pistar-zumspotflash libre`: ZUMspot Libre Kit or generic MMDVM_HS board with USB
+- `sudo pistar-mmdvmhshatflash hs_hat`: MMDVM_HS_Hat board (14.7456MHz TCXO)
+- `sudo pistar-mmdvmhshatflash hs_dual_hat`: HS_DUAL_HAT board (14.7456MHz TCXO)
+- `sudo pistar-mmdvmhshatflash hs_hat-12mhz`: MMDVM_HS_Hat board (12.288MHz TCXO)
+- `sudo pistar-mmdvmhshatflash hs_dual_hat-12mhz`: HS_DUAL_HAT board (12.288MHz TCXO)
+- `sudo pistar-nanohsflash nano_hs`: Nano hotSPOT board
+- `sudo pistar-nanodvflash pi`: NanoDV NPi board
+- `sudo pistar-nanodvflash usb`: NanoDV USB board
+- `sudo pistar-skybridgeflash skybrige`: BridgeCom SkyBridge GPIO Hotspot board
 
 ### Windows
 

--- a/build_fw.sh
+++ b/build_fw.sh
@@ -1,0 +1,1 @@
+scripts/build_fw.sh

--- a/scripts/build_fw.sh
+++ b/scripts/build_fw.sh
@@ -16,6 +16,10 @@
 #   along with this program; if not, write to the Free Software
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
+if [ ! -d ~/MMDVM_HS ] ; then
+    mkdir ~/MMDVM_HS
+fi
+
 echo "******************************************************"
 echo "********* Cleaning objects and updating code *********"
 echo "******************************************************"
@@ -23,12 +27,17 @@ cd ~/MMDVM_HS/
 make clean
 git pull
 
+# Download STM32F10X_Lib (only for binary tools)
+if [ ! -d "./STM32F10X_Lib/utils" ]; then
+  git clone https://github.com/juribeparada/STM32F10X_Lib
+fi
+
 # Building ZUMspot Libre Kit
 echo "*******************************************************"
 echo "********* Building ZUMspot Libre Kit firmware *********"
 echo "*******************************************************"
 cp ~/MMDVM_HS/configs/ZUMspot_Libre.h ~/MMDVM_HS/Config.h
-make -j4 bl
+make -j5 bl
 mv ~/MMDVM_HS/bin/mmdvm_f1bl.bin ~/MMDVM_HS/bin/zumspot_libre_fw.bin
 make clean
 
@@ -37,7 +46,7 @@ echo "*************************************************"
 echo "********* Building ZUMspot RPi firmware *********"
 echo "*************************************************"
 cp ~/MMDVM_HS/configs/ZUMspot_RPi.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/zumspot_rpi_fw.bin
 make clean
 
@@ -46,7 +55,7 @@ echo "*************************************************"
 echo "********* Building ZUMspot USB firmware *********"
 echo "*************************************************"
 cp ~/MMDVM_HS/configs/ZUMspot_USB.h ~/MMDVM_HS/Config.h
-make -j4 bl
+make -j5 bl
 mv ~/MMDVM_HS/bin/mmdvm_f1bl.bin ~/MMDVM_HS/bin/zumspot_usb_fw.bin
 make clean
 
@@ -55,7 +64,7 @@ echo "****************************************************"
 echo "********* Building ZUMspot Duplex firmware *********"
 echo "****************************************************"
 cp ~/MMDVM_HS/configs/ZUMspot_duplex.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/zumspot_duplex_fw.bin
 make clean
 
@@ -64,7 +73,7 @@ echo "******************************************************"
 echo "********* Building ZUMspot Dualband firmware *********"
 echo "******************************************************"
 cp ~/MMDVM_HS/configs/ZUMspot_dualband.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/zumspot_dualband_fw.bin
 make clean
 
@@ -73,7 +82,7 @@ echo "**************************************************"
 echo "********* Building MMDVM_HS_Hat firmware *********"
 echo "**************************************************"
 cp ~/MMDVM_HS/configs/MMDVM_HS_Hat.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/mmdvm_hs_hat_fw.bin
 make clean
 
@@ -82,7 +91,7 @@ echo "********************************************************************"
 echo "********* Building MMDVM_HS_Hat (12.288 MHz TCXO) firmware *********"
 echo "********************************************************************"
 cp ~/MMDVM_HS/configs/MMDVM_HS_Hat-12mhz.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/mmdvm_hs_hat_fw-12mhz.bin
 make clean
 
@@ -91,7 +100,7 @@ echo "*******************************************************"
 echo "********* Building MMDVM_HS_Dual_Hat firmware *********"
 echo "*******************************************************"
 cp ~/MMDVM_HS/configs/MMDVM_HS_Dual_Hat.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/mmdvm_hs_dual_hat_fw.bin
 make clean
 
@@ -100,7 +109,7 @@ echo "*************************************************************************"
 echo "********* Building MMDVM_HS_Dual_Hat (12.288 MHz TCXO) firmware *********"
 echo "*************************************************************************"
 cp ~/MMDVM_HS/configs/MMDVM_HS_Dual_Hat-12mhz.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/mmdvm_hs_dual_hat_fw-12mhz.bin
 make clean
 
@@ -109,7 +118,7 @@ echo "**************************************************"
 echo "********* Building Nano hotSPOT firmware *********"
 echo "**************************************************"
 cp ~/MMDVM_HS/configs/Nano_hotSPOT.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/nano_hotspot_fw.bin
 make clean
 
@@ -118,7 +127,7 @@ echo "************************************************"
 echo "********* Building NanoDV NPi firmware *********"
 echo "************************************************"
 cp ~/MMDVM_HS/configs/NanoDV_NPi.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/nanodv_npi_fw.bin
 make clean
 
@@ -127,7 +136,7 @@ echo "************************************************"
 echo "********* Building NanoDV USB firmware *********"
 echo "************************************************"
 cp ~/MMDVM_HS/configs/NanoDV_USB.h ~/MMDVM_HS/Config.h
-make -j4 bl
+make -j5 bl
 mv ~/MMDVM_HS/bin/mmdvm_f1bl.bin ~/MMDVM_HS/bin/nanodv_usb_fw.bin
 make clean
 
@@ -136,7 +145,7 @@ echo "***************************************************"
 echo "********* Building D2RG MMDVM_HS firmware *********"
 echo "***************************************************"
 cp ~/MMDVM_HS/configs/D2RG_MMDVM_HS.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/d2rg_mmdvm_hs.bin
 make clean
 
@@ -145,7 +154,7 @@ echo "**********************************************************"
 echo "********* Building Generic Simplex GPIO firmware *********"
 echo "**********************************************************"
 cp ~/MMDVM_HS/configs/generic_gpio.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/generic_gpio_fw.bin
 make clean
 
@@ -154,7 +163,7 @@ echo "*********************************************************"
 echo "********* Building Generic Duplex GPIO firmware *********"
 echo "*********************************************************"
 cp ~/MMDVM_HS/configs/generic_duplex_gpio.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/generic_duplex_gpio_fw.bin
 make clean
 
@@ -163,7 +172,7 @@ echo "********************************************************"
 echo "********* Building Generic Duplex USB firmware *********"
 echo "********************************************************"
 cp ~/MMDVM_HS/configs/generic_duplex_usb.h ~/MMDVM_HS/Config.h
-make -j4 bl
+make -j5 bl
 mv ~/MMDVM_HS/bin/mmdvm_f1bl.bin ~/MMDVM_HS/bin/generic_duplex_usb_fw.bin
 make clean
 
@@ -172,7 +181,7 @@ echo "******************************************************"
 echo "********* Building SkyBridge RPi HS firmware *********"
 echo "******************************************************"
 cp ~/MMDVM_HS/configs/SkyBridge_RPi.h ~/MMDVM_HS/Config.h
-make -j4
+make -j5
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/skybridge_rpi_fw.bin
 make clean
 
@@ -181,8 +190,14 @@ echo "*************************************************"
 echo "********* Building LoneStar USB firmware *********"
 echo "*************************************************"
 cp ~/MMDVM_HS/configs/LoneStar_USB.h ~/MMDVM_HS/Config.h
-make -j4 bl
+make -j5 bl
 mv ~/MMDVM_HS/bin/mmdvm_f1bl.bin ~/MMDVM_HS/bin/lonestar_usb_fw.bin
 make clean
 
 cp ~/MMDVM_HS/configs/ZUMspot_Libre.h ~/MMDVM_HS/Config.h
+
+cd ~/MMDVM_HS/bin
+md5sum *.bin > MD5SUMS.txt
+#git add .
+#git commit  -a -m 'Updated FW bins'
+#git push

--- a/scripts/build_fw.sh
+++ b/scripts/build_fw.sh
@@ -25,6 +25,7 @@ echo "********* Cleaning objects and updating code *********"
 echo "******************************************************"
 cd ~/MMDVM_HS/
 make clean
+rm -rf bin/*.bin
 git pull
 
 # Download STM32F10X_Lib (only for binary tools)

--- a/scripts/install_fw_custom.sh
+++ b/scripts/install_fw_custom.sh
@@ -49,6 +49,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_d2rg_mmdvmhs.sh
+++ b/scripts/install_fw_d2rg_mmdvmhs.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_dualband.sh
+++ b/scripts/install_fw_dualband.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_duplex.sh
+++ b/scripts/install_fw_duplex.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_duplex_gpio.sh
+++ b/scripts/install_fw_duplex_gpio.sh
@@ -50,6 +50,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_duplex_gpio_opi.sh
+++ b/scripts/install_fw_duplex_gpio_opi.sh
@@ -50,6 +50,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_duplex_usb.sh
+++ b/scripts/install_fw_duplex_usb.sh
@@ -51,6 +51,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_gen_gpio.sh
+++ b/scripts/install_fw_gen_gpio.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_hsdualhat-12mhz.sh
+++ b/scripts/install_fw_hsdualhat-12mhz.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_hsdualhat.sh
+++ b/scripts/install_fw_hsdualhat.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_hshat-12mhz.sh
+++ b/scripts/install_fw_hshat-12mhz.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_hshat.sh
+++ b/scripts/install_fw_hshat.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_librekit.sh
+++ b/scripts/install_fw_librekit.sh
@@ -51,6 +51,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_lonestar_usb.sh
+++ b/scripts/install_fw_lonestar_usb.sh
@@ -51,6 +51,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_nanodv_npi.sh
+++ b/scripts/install_fw_nanodv_npi.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_nanodv_usb.sh
+++ b/scripts/install_fw_nanodv_usb.sh
@@ -51,6 +51,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_nanohs.sh
+++ b/scripts/install_fw_nanohs.sh
@@ -58,6 +58,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_rpi.sh
+++ b/scripts/install_fw_rpi.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_skybridge_rpi.sh
+++ b/scripts/install_fw_skybridge_rpi.sh
@@ -47,6 +47,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"

--- a/scripts/install_fw_usb.sh
+++ b/scripts/install_fw_usb.sh
@@ -51,6 +51,12 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "aarch64" ] ; then
+		echo "Raspberry Pi 4 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
 		echo "Raspberry Pi 3 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"


### PR DESCRIPTION
This PR adds aarch64 (RPi-4) support logic to the FW installation scripts.