### PR TITLE
Updated FW install scripts to use newly-hosted v.1.6.1 binaries

### DIFF
--- a/scripts/install_fw_custom.sh
+++ b/scripts/install_fw_custom.sh
@@ -37,7 +37,7 @@ fi
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -50,19 +50,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_d2rg_mmdvmhs.sh
+++ b/scripts/install_fw_d2rg_mmdvmhs.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
+FW_VERSION="v1.6.1"
 	
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
-
 # Firmware filename
 FW_FILENAME="d2rg_mmdvm_hs.bin"
 	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -48,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_dualband.sh
+++ b/scripts/install_fw_dualband.sh
@@ -17,26 +17,15 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
+FW_VERSION="v1.6.1"
 
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
-
-# Firmware filename
-FW_FILENAME="zumspot_dualband_fw.bin"
-	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -48,19 +37,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_duplex.sh
+++ b/scripts/install_fw_duplex.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="zumspot_duplex_fw.bin"
-	
+
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME	
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -48,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_duplex_gpio.sh
+++ b/scripts/install_fw_duplex_gpio.sh
@@ -17,29 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="generic_duplex_gpio_fw.bin"
 	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
-
-# Download latest firmware for Generic Duplex GPIO
-curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -51,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_duplex_gpio_opi.sh
+++ b/scripts/install_fw_duplex_gpio_opi.sh
@@ -17,29 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="generic_duplex_gpio_fw.bin"
-	
-# Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
 
-# Download latest firmware for Generic Duplex GPIO
-curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/
+# Download latest firmware
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -51,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_duplex_usb.sh
+++ b/scripts/install_fw_duplex_usb.sh
@@ -17,29 +17,21 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
+FW_VERSION="v1.6.1"
 
 # Change USB-serial port name ONLY in macOS
 MAC_DEV_USB_SER="/dev/cu.usbmodem14401"
 
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
-
 # Firmware filename
 FW_FILENAME="generic_duplex_usb_fw.bin"
-	
+
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -52,19 +44,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_gen_gpio.sh
+++ b/scripts/install_fw_gen_gpio.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="generic_gpio_fw.bin"
-	
+
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -48,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_hsdualhat-12mhz.sh
+++ b/scripts/install_fw_hsdualhat-12mhz.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="mmdvm_hs_dual_hat_fw-12mhz.bin"
-	
+
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME	
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -48,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_hsdualhat.sh
+++ b/scripts/install_fw_hsdualhat.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="mmdvm_hs_dual_hat_fw.bin"
 	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -48,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_hshat-12mhz.sh
+++ b/scripts/install_fw_hshat-12mhz.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="mmdvm_hs_hat_fw-12mhz.bin"
-	
-# Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
 
+# Download latest firmware
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
+	
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -48,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_hshat.sh
+++ b/scripts/install_fw_hshat.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="mmdvm_hs_hat_fw.bin"
 	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -48,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_librekit.sh
+++ b/scripts/install_fw_librekit.sh
@@ -17,29 +17,21 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
+FW_VERSION="v1.6.1"
 
 # Change USB-serial port name ONLY in macOS
 MAC_DEV_USB_SER="/dev/cu.usbmodem14401"
 
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
-
 # Firmware filename
 FW_FILENAME="zumspot_libre_fw.bin"
-	
+
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME	
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -52,19 +44,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_lonestar_usb.sh
+++ b/scripts/install_fw_lonestar_usb.sh
@@ -17,29 +17,21 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.6.0"
+FW_VERSION="v1.6.1"
 
 # Change USB-serial port name ONLY in macOS
 MAC_DEV_USB_SER="/dev/cu.usbmodem14401"
-
-# Configure beta version
-FW_VERSION_BETA="v1.6.0b"
 
 # Firmware filename
 FW_FILENAME="lonestar_usb_fw.bin"
 	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -52,19 +44,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_nanodv_npi.sh
+++ b/scripts/install_fw_nanodv_npi.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="nanodv_npi_fw.bin"
-	
+
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME	
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -48,19 +40,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_nanodv_usb.sh
+++ b/scripts/install_fw_nanodv_usb.sh
@@ -17,29 +17,20 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
+FW_VERSION="v1.6.1"
 
 # Change USB-serial port name ONLY in macOS
 MAC_DEV_USB_SER="/dev/cu.usbmodem14401"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
 
 # Firmware filename
 FW_FILENAME="nanodv_usb_fw.bin"
 	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
-# Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -52,19 +43,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_nanohs.sh
+++ b/scripts/install_fw_nanohs.sh
@@ -28,26 +28,18 @@ if [ -f /etc/pistar-release ]; then
 fi
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="nano_hotspot_fw.bin"
 	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -59,19 +51,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_rpi.sh
+++ b/scripts/install_fw_rpi.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="zumspot_rpi_fw.bin"
 	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -47,20 +39,20 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
-	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
-		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
-		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
-		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
-		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
+	elif [ $(uname -m) == "aarch64" ]; then
+		echo "Raspberry Pi 4 aarch64 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_skybridge_rpi.sh
+++ b/scripts/install_fw_skybridge_rpi.sh
@@ -17,26 +17,18 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
+FW_VERSION="v1.6.1"
 
 # Firmware filename
 FW_FILENAME="skybridge_rpi_fw.bin"
-	
-# Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
 
+# Download latest firmware
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME	
+	
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -47,20 +39,20 @@ if [ $(uname -s) == "Linux" ]; then
 		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
-	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
-		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
-		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
-		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
-		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
+	elif [ $(uname -m) == "aarch64" ]; then
+		echo "Raspberry Pi 4 aarch64 detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"

--- a/scripts/install_fw_usb.sh
+++ b/scripts/install_fw_usb.sh
@@ -17,29 +17,21 @@
 #   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 # Configure latest version
-FW_VERSION="v1.5.2"
+FW_VERSION="v1.6.1"
 
 # Change USB-serial port name ONLY in macOS
 MAC_DEV_USB_SER="/dev/cu.usbmodem14401"
-
-# Configure beta version
-FW_VERSION_BETA="v1.5.1b"
 
 # Firmware filename
 FW_FILENAME="zumspot_usb_fw.bin"
 	
 # Download latest firmware
-if [ $1 = "beta" ]; then
-	echo "Downloading beta firmware..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
-else
-	echo "Downloading latest firmware (stable)..."
-	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
-fi
+echo "Downloading firmware..."
+curl -s -A "CA6JAU/G4KLX/W0CHP Modem FW Update Script" -OL https://wpsd-swd.w0chp.net/WPSD-SWD/MMDVM_HS-Firmware_Latest-Compiled/raw/tag/$FW_VERSION/$FW_FILENAME
 
 # Download STM32F10X_Lib (only for binary tools)
 if [ ! -d "./STM32F10X_Lib/utils" ]; then
-  git clone https://github.com/juribeparada/STM32F10X_Lib
+  env GIT_HTTP_CONNECT_TIMEOUT="10" env GIT_HTTP_USER_AGENT="CA6JAU/G4KLX/W0CHP Modem FW Update Script" git clone https://wpsd-swd.w0chp.net/WPSD-SWD/STM32F10X_Lib.git &> /dev/null
 fi
 
 # Configure vars depending on OS
@@ -52,19 +44,19 @@ if [ $(uname -s) == "Linux" ]; then
 		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
 	elif [ $(uname -m) == "aarch64" ] ; then
-		echo "Raspberry Pi 4 detected"
+		echo "Linux 64-bit ARM (aarch64) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv7l" ]; then
-		echo "Raspberry Pi 3 detected"
+		echo "Linux ARM (armv7l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
 		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
 	elif [ $(uname -m) == "armv6l" ]; then
-		echo "Raspberry Pi 2 or Pi Zero W detected"
+		echo "Linux ARM (armv6l) detected"
 		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
 		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
 		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"


### PR DESCRIPTION
Updated FW install scripts to use newly-hosted v.1.6.1 FW binaries requested by `KI6ZUM` et. al.

As the scripts currently stand, they will _only_ allow users to install v1.5.2 binaries (the outdated latest available in the `CA6JAU` GH repo.).

I've been asked to provide binary hosting[^1], but these scripts needed to be updated to actually use the new FW binaries.

[^1]: The mirror is operated & sponsored by the @M17-Project & the WPSD Project